### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 联系邮箱: easyulife@gmail.com 
 讨论Q群: 188255611
 
-####WebSite: [RainReminder-Swift天气应用](http://www.tongchao.xyz/2016/05/04/rainreminder-swifttian-qi-ying-yong/)  
-####AppStore: [已上架AppStore](https://itunes.apple.com/us/app/rainreminder/id1102738128?l=zh&ls=1&mt=8)   
+#### WebSite: [RainReminder-Swift天气应用](http://www.tongchao.xyz/2016/05/04/rainreminder-swifttian-qi-ying-yong/)  
+#### AppStore: [已上架AppStore](https://itunes.apple.com/us/app/rainreminder/id1102738128?l=zh&ls=1&mt=8)   
 
 ## GIF
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
